### PR TITLE
Integrated with the build

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -154,6 +154,23 @@
                         </configuration>
                     </execution>
 
+                    <execution>
+                        <id>webpack-build</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+
+                        <configuration>
+                            <executable>./node_modules/.bin/webpack</executable>
+                            <workingDirectory>src/main/webapp</workingDirectory>
+                            <arguments>
+                                <argument>--progress</argument>
+                                <argument>--profile</argument>
+                                <argument>--bail</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/ui/src/main/webapp/WEB-INF/web.xml
+++ b/ui/src/main/webapp/WEB-INF/web.xml
@@ -45,6 +45,7 @@
     <servlet-mapping>
         <servlet-name>Freemarker</servlet-name>
         <url-pattern>*.ftl</url-pattern>
+        <url-pattern>/index.html</url-pattern>
         <url-pattern>/not_loggedin.html</url-pattern>
         <url-pattern>/keycloak.json</url-pattern>
         <url-pattern>/tests/unit-tests.html</url-pattern>

--- a/ui/src/main/webapp/package.json
+++ b/ui/src/main/webapp/package.json
@@ -22,7 +22,7 @@
     "docs": "typedoc --options typedoc.json src/app/app.component.ts",
     "start": "npm run server",
     "start:hmr": "npm run server -- --hot",
-    "postinstall": "npm run webdriver-update"
+    "postinstall": "./node_modules/.bin/typings install"
   },
   "dependencies": {
     "@angular/common": "2.0.1",
@@ -106,7 +106,8 @@
     "tslint": "^3.4.0",
     "tslint-loader": "^2.1.0",
     "typedoc": "^0.4.4",
-    "typescript": "2.0.2",
+    "typescript": "2.0.3",
+    "typings": "1.4.0",
     "url-loader": "^0.5.6",
     "webpack": "^2.1.0-beta.25",
     "webpack-dev-server": "2.1.0-beta.9"

--- a/ui/src/main/webapp/typings.json
+++ b/ui/src/main/webapp/typings.json
@@ -1,6 +1,6 @@
 {
   "globalDependencies": {
-    "keycloak": "https://raw.githubusercontent.com/hawtio/hawtio/master/hawtio-web/src/main/d.ts/keycloak.d.ts",
+    "keycloak": "https://raw.githubusercontent.com/hawtio/hawtio/master/hawtio-web/src/main/d.ts/keycloak.d.ts"
   },
   "dependencies": {
     "windup-services": "file:../../../../services/target/windup-services.d.ts"

--- a/ui/src/test/java/org/jboss/windup/web/ui/AbstractUITest.java
+++ b/ui/src/test/java/org/jboss/windup/web/ui/AbstractUITest.java
@@ -136,8 +136,10 @@ public abstract class AbstractUITest
         };
 
         getDriver().navigate().to(getContextRoot());
-        Thread.sleep(5000);
         printBrowserLogs();
+
+        takeScreenshot("AbstractUITest", getDriver());
+        System.out.println("Page source: " + getDriver().getPageSource());
 
         wait.withTimeout(10, TimeUnit.SECONDS).until(loginButtonIsAvailable);
         WebElement loginElement = getDriver().findElement(By.id(SPLASH_PAGE_LOGIN_BUTTON_ID));


### PR DESCRIPTION
This reintegrates it with the build. A couple of things that I've noticed:
- This gets rid of the splash screen on initial login. I think that we want that.
- Getting rid of the splash screen causes the Java UI tests to fail
- This probably also keeps the jasmine tests from running

Also, the styling still seems slightly different for some reason. I don't think this is a reason to not merge it, but the table border widths seem larger. I'm not really sure what is going on there.
